### PR TITLE
[nightshift] changelog-synth: add CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,47 @@
+# Changelog
+
+All notable changes to the scoop-kagi bucket manifest.
+
+## [0.4.3] - 2026-04-16
+
+- Update kagi manifest for v0.4.3
+
+## [0.4.2] - 2026-04-11
+
+- Update kagi manifest for v0.4.2
+
+## [0.4.1] - 2026-04-03
+
+- Update kagi manifest for v0.4.1
+
+## [0.4.0] - 2026-03-29
+
+- Update kagi manifest for v0.4.0
+
+## [0.3.3] - 2026-03-23
+
+- Update kagi manifest for v0.3.3
+
+## [0.3.2] - 2026-03-22
+
+- Update kagi manifest for v0.3.2
+
+## [0.3.1] - 2026-03-20
+
+- Update kagi manifest for v0.3.1
+
+## [0.3.0] - 2026-03-19
+
+- Update kagi manifest for v0.3.0
+
+## [0.1.7] - 2026-03-17
+
+- Update kagi manifest for v0.1.7
+
+## [0.1.6] - 2026-03-16
+
+- Update kagi manifest for v0.1.6
+
+## [Initial] - 2026-03-16
+
+- feat: add kagi manifest for Scoop package manager


### PR DESCRIPTION
Automated by Nightshift v3 (GLM 5.1).

**Task:** changelog-synth
**Category:** pr

**Changes:**
- Generated CHANGELOG.md from full commit history (14 commits, v0.1.6 → v0.4.3)
- Chronological version entries from initial manifest to current release

**Note:** The root `kagi.json` appears stale at v0.3.1 while `bucket/kagi.json` is at v0.4.3. Consider removing the root-level duplicate or syncing it.

Merge if useful, close if not.