### PR TITLE
nightshift: readme-improvements — expand README with usage examples and context

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # scoop-kagi
 
-Scoop bucket for the `kagi` CLI.
+[Scoop](https://scoop.sh/) bucket for [kagi-cli](https://github.com/Microck/kagi-cli) — an agent-native Rust CLI for Kagi subscribers with JSON-first output.
 
 ## Install
 
@@ -9,9 +9,36 @@ scoop bucket add kagi https://github.com/Microck/scoop-kagi
 scoop install kagi
 ```
 
-## Upgrade
+## Usage
 
 ```powershell
-scoop update
+# Search the web
+kagi search "rust async patterns"
+
+# Get a quick answer
+kagi quick "what is the capital of Portugal"
+
+# Fetch news
+kagi news
+
+# Summarize a URL
+kagi summarize https://example.com/article
+```
+
+## Update
+
+```powershell
 scoop update kagi
 ```
+
+The manifest uses Scoop's autoupdate feature, so new releases are picked up automatically from the [kagi-cli releases page](https://github.com/Microck/kagi-cli/releases).
+
+## Requirements
+
+- [Scoop](https://scoop.sh/) package manager
+- Windows x86_64
+- A [Kagi](https://kagi.com/) subscription (for API features)
+
+## License
+
+The kagi-cli tool is licensed under [MIT](https://github.com/Microck/kagi-cli/blob/main/LICENSE).


### PR DESCRIPTION
## Summary

Expand the README with usage examples and additional context for the scoop-kagi bucket.

## Changes

- Added usage examples for common `kagi` CLI commands (`search`, `quick`, `news`, `summarize`)
- Documented requirements (Scoop, Windows x86_64, Kagi subscription)
- Explained autoupdate behavior from GitHub releases
- Added license reference section

## Testing

- Markdown rendering verified manually

---
🤖 Automated by [nightshift](https://github.com/Microck/hermes-nightshift-glm) — `readme-improvements` task
